### PR TITLE
Update input_lists.json to remove SNLComputation

### DIFF
--- a/_explore/input_lists.json
+++ b/_explore/input_lists.json
@@ -4,8 +4,7 @@
         "sandialabs",
         "smashtoolbox",
         "snl-gms",
-        "snl-waterpower",
-        "snlcomputation"
+        "snl-waterpower"
     ],
     "repos": [
         "bartvbw/milo",


### PR DESCRIPTION
The GitHub.com Organization named "SNLComputation" is no longer relevant. The repos in this org are not needing to be on the Sandia Software Portal, but if they did need to be, we would add them individually instead.