### PR TITLE
Removing Active Dropdown for `About`

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,13 +14,8 @@
 
     <div id="siteNavbar" class="collapse navbar-collapse">
       <ul class="nav navbar-nav navbar-right navbar-collapse">
-        <li id="about"
-            {% if page.url == "/about/" %} class="active dropdown"
-            {% else %} class="dropdown"
-            {% endif %}><a class="navbar-normal" href="/about/">About</a>
-          <div class="dropdown-content">
-            <p><a class="navbar-normal" href="/about/faq/">FAQ</a></p>
-          </div>
+        <li id="about">
+            <a class="navbar-normal" href="/about/">About</a>
         </li>
 
         <li id="explore"


### PR DESCRIPTION
I neglected to remove the active dropdown for `About` in my last PR. This takes care of that.

![Screen Shot 2021-11-29 at 4 49 05 PM](https://user-images.githubusercontent.com/55767766/143960614-c5dedd5e-8efe-4823-96a2-6100aa0933c4.png)
