### PR TITLE
Add DARMA-tasking Organization

### DIFF
--- a/_explore/input_lists.json
+++ b/_explore/input_lists.json
@@ -1,5 +1,6 @@
 {
     "orgs": [
+        "darma-tasking",
         "mantevo",
         "sandialabs",
         "smashtoolbox",


### PR DESCRIPTION
This is linked to help desk ticket 3159. This PR adds the org [`DARMA-tasking`](https://github.com/DARMA-tasking) to the organizations tracked on software.sandia.gov.