### PR TITLE
fix: Update GitHub link in site nav bar

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -35,7 +35,7 @@
             <p><a class="navbar-normal" href="/explore/popular-repos/">Popular Repositories</a></p>
           </div>
         </li>
-        <li id="github-button"><a href="https://github.com/ornl"><span class="fa fa-github fa-lg"></span></a></li>
+        <li id="github-button"><a href="https://github.com/sandialabs"><span class="fa fa-github fa-lg"></span></a></li>
         <li id="twitter-button"><a href="https://twitter.com/{{site.twitter.username}}"><span class="fa fa-twitter fa-lg"></span></a></li>
       </ul>
     </div>


### PR DESCRIPTION
When this repository was forked from ORNL, it looks like we missed updating the GitHub icon in the site navigation bar to point to the `sandialabs` organization on GitHub instead of the `ornl` one.  Thanks to @GhostofGoes for noticing.